### PR TITLE
Allow pluggable transport.

### DIFF
--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -14,7 +14,6 @@ import (
 	rpcjson "github.com/gohttp/rpc/json"
 )
 
-// Client.
 type Client interface {
 	Call(method string, args interface{}, res interface{}) error
 	CallContext(context.Context, string, interface{}, interface{}) error
@@ -45,7 +44,9 @@ type client struct {
 	addr string
 }
 
-// Call calls the given RPC method with the given arguments.
+// CallContext calls the given RPC method with the given arguments. args is
+// serialized to JSON before sending to the remote server. The response is
+// decoded into res.
 func (c *client) Call(method string, args interface{}, res interface{}) error {
 	return c.CallContext(context.Background(), method, args, res)
 }
@@ -68,6 +69,11 @@ func (c *client) CallContext(ctx context.Context, method string, args interface{
 	r = r.WithContext(ctx)
 
 	r.Header.Set("Content-Type", "application/json")
+
+	if c.http == nil {
+		c.http = http.DefaultClient
+	}
+
 	resp, err := c.http.Do(r)
 	if err != nil {
 		return err

--- a/options.go
+++ b/options.go
@@ -1,0 +1,39 @@
+package jsonrpc
+
+import (
+	"net/http"
+	"time"
+)
+
+type Option interface {
+	apply(*client) error
+}
+
+func NewClientWithOptions(addr string, options ...Option) (Client, error) {
+	c := &client{
+		addr: addr,
+	}
+	for _, o := range options {
+		err := o.apply(c)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c, nil
+}
+
+type optionFunc func(*client) error
+
+func (o optionFunc) apply(c *client) error {
+	return o(c)
+}
+
+func RoundTripper(rt http.RoundTripper) optionFunc {
+	return optionFunc(func(c *client) error {
+		c.http = &http.Client{
+			Transport: rt,
+			Timeout:   10 * time.Minute,
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
This lets users to set a custom round tripper.

In my specific case, I want to use https://github.com/f2prateek/train to
transparently set a user agent on all outgoing requests.

For performance improvements, a plugged in transport will require the
user to set the cached dns resolver manually.

Usage would be something like:

```
dialer := &nett.Dialer{
      Resolver:  &nett.CacheResolver{TTL: 5 * time.Minute},
      Timeout:   1 * time.Minute,
      KeepAlive: 1 * time.Minute,
}
rt = &http.Transport{
      Dial:                dialer.Dial,
      MaxIdleConnsPerHost: 512,
}

transport := train.TransportWith(rt, train.InterceptorFunc(func(chain train.Chain) (*http.Response, error) {
  req := chain.Request()
  req.Header.Add("User-Agent", "segment/xid:(1.2.3)")
  resp, err := chain.Proceed(req)
  return resp, err
}))

client := jsonrpc.NewClientWithOptions("addr", jsonrpc.RoundTripper(transport))
```