### PR TITLE
Support Contexts

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,17 @@
+package jsonrpc
+
+import (
+	"context"
+	"fmt"
+)
+
+func Example() {
+	c := NewClient("http://localhost:5000/rpc")
+	type User struct {
+		Email string
+	}
+	u := new(User)
+	err := c.CallContext(context.TODO(), "User.GetOne", "test@example.com", u)
+	fmt.Println(err)
+	fmt.Println(u.Email)
+}

--- a/rpcmock/mock.go
+++ b/rpcmock/mock.go
@@ -1,6 +1,7 @@
 package rpcmock
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/stretchr/testify/mock"
@@ -18,6 +19,17 @@ func NewClient() *Client {
 func (c *Client) Call(method string, params, result interface{}) error {
 	args := c.Called(method, params, result)
 	return args.Error(0)
+}
+
+func (c *Client) CallContext(ctx context.Context, method string, params, result interface{}) error {
+	// Reverse order here, since we shouldn't be hitting the network during this
+	// test.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	return c.Call(method, params, result)
 }
 
 func (c *Client) MockResponse(method string, params, response interface{}) {

--- a/rpcmock/mock_test.go
+++ b/rpcmock/mock_test.go
@@ -1,6 +1,7 @@
 package rpcmock
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -31,4 +32,12 @@ func TestMock(t *testing.T) {
 	assert.Equal(t, "", response)
 	assert.Equal(t, errors.New("somebody set up the bomb"), err)
 	c.AssertExpectations(t)
+}
+
+func TestCallContextError(t *testing.T) {
+	c := NewClient()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := c.CallContext(ctx, "RPC.Test", "hello", nil)
+	assert.Equal(t, err, context.Canceled)
 }


### PR DESCRIPTION
Add a second CallContext function that you can use to pass a
context.Context to an RPC call. This makes it easy to coordinate
cancelation across a number of different goroutines, and have one
failure make every request fail.

Add an example of RPC usage, and a test for the new context code.