### PR TITLE
Add support for setting custom User-Agent

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,8 +7,13 @@ View the [docs](http://godoc.org/github.com/gohttp/jsonrpc-client).
 # Example
 
 ``` go
-jsonrpc.New("http://localhost:4000/rpc")
+c := jsonrpc.NewClient("http://localhost:4000/rpc")
 err := c.Call("Coupon.GetById", map[string]string{"id": "trial"}, &res)
+```
+
+``` go
+c, _ := jsonrpc.NewClientWithOptions("http://localhost:4000/rpc", jsonrpc.UserAgent("rpc_bot/1.0"))
+err := c.Call("Coupon.Apply", map[string]string{"account_id": "abcd1234", "coupon_id": "trial"}, &res)
 ```
 
 # License

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -40,8 +40,9 @@ func NewClient(addr string) Client {
 }
 
 type client struct {
-	http *http.Client
-	addr string
+	http      *http.Client
+	addr      string
+	userAgent string
 }
 
 // CallContext calls the given RPC method with the given arguments. args is
@@ -71,6 +72,10 @@ func (c *client) CallContext(ctx context.Context, method string, args interface{
 	r.Header.Set("Content-Type", "application/json; charset=utf-8")
 	r.Header.Set("Accept", "application/json")
 	r.Header.Set("Accept-Charset", "utf-8")
+
+	if c.userAgent != "" {
+		r.Header.Set("User-Agent", c.userAgent)
+	}
 
 	if c.http == nil {
 		c.http = http.DefaultClient

--- a/options.go
+++ b/options.go
@@ -37,3 +37,10 @@ func RoundTripper(rt http.RoundTripper) optionFunc {
 		return nil
 	})
 }
+
+func UserAgent(userAgent string) optionFunc {
+	return optionFunc(func(c *client) error {
+		c.userAgent = userAgent
+		return nil
+	})
+}


### PR DESCRIPTION
This adds support for setting a custom User-Agent string to include in the http requests.
It uses the existing `NewClientWithOptions` customization method to avoid changing any exported signatures.